### PR TITLE
Fixed how Solana transaction are indexed when using program + account

### DIFF
--- a/solana-common/src/index.rs
+++ b/solana-common/src/index.rs
@@ -1,11 +1,13 @@
 use substreams::pb::sf::substreams::index::v1::Keys;
 use substreams_solana::pb::sf::solana::r#type::v1::Block;
 
+use crate::keys::transaction_program_and_account_keys;
+
 #[substreams::handlers::map]
 fn program_ids_without_votes(block: Block) -> Result<Keys, substreams::errors::Error> {
     let keys: Vec<String> = block
         .walk_instructions()
-        .map(|inst| format!("program:{}", inst.program_id().to_string()))
+        .map(|inst| format!("program:{}", inst.program_id()))
         .collect();
 
     Ok(Keys { keys })
@@ -13,15 +15,10 @@ fn program_ids_without_votes(block: Block) -> Result<Keys, substreams::errors::E
 
 #[substreams::handlers::map]
 fn program_ids_and_accounts_without_votes(block: Block) -> Result<Keys, substreams::errors::Error> {
-    let keys: Vec<String> = block
-        .walk_instructions()
-        .flat_map(|inst| {
-            inst.accounts()
-                .into_iter()
-                .map(|acc| format!("account:{}", acc))
-                .chain(vec![format!("program:{}", inst.program_id())])
-        })
-        .collect();
-
-    Ok(Keys { keys })
+    Ok(Keys {
+        keys: block
+            .transactions()
+            .flat_map(transaction_program_and_account_keys)
+            .collect(),
+    })
 }

--- a/solana-common/src/keys.rs
+++ b/solana-common/src/keys.rs
@@ -1,0 +1,22 @@
+use substreams_solana::{base58, pb::sf::solana::r#type::v1::ConfirmedTransaction};
+
+/// transaction_program_and_account_keys returns an iterator of keys extracted from a transaction. It will
+/// emit the account keys from the transaction message, the loaded writable addresses, the loaded readonly
+/// addresses, and the program ids from the instructions.
+pub(crate) fn transaction_program_and_account_keys(
+    trx: &ConfirmedTransaction,
+) -> impl Iterator<Item = String> + '_ {
+    let meta = trx.meta.as_ref().unwrap();
+    let message = trx.transaction.as_ref().unwrap().message.as_ref().unwrap();
+
+    message
+        .account_keys
+        .iter()
+        .chain(meta.loaded_writable_addresses.iter())
+        .chain(meta.loaded_readonly_addresses.iter())
+        .map(|acct| format!("account:{}", base58::encode(acct)))
+        .chain(
+            trx.walk_instructions()
+                .map(|inst| format!("program:{}", inst.program_id())),
+        )
+}

--- a/solana-common/src/lib.rs
+++ b/solana-common/src/lib.rs
@@ -1,5 +1,6 @@
 mod block;
 mod index;
+mod keys;
 mod pb;
 #[cfg(test)]
 mod testing;

--- a/solana-common/src/transaction.rs
+++ b/solana-common/src/transaction.rs
@@ -1,4 +1,6 @@
-use crate::pb::sf::substreams::solana::v1::Transactions;
+use crate::{
+    keys::transaction_program_and_account_keys, pb::sf::substreams::solana::v1::Transactions,
+};
 use substreams_solana::pb::sf::solana::r#type::v1::Block;
 
 #[substreams::handlers::map]
@@ -48,16 +50,9 @@ fn _transactions_by_programid_and_account_without_votes(
     };
 
     transactions.transactions.retain(|trx| {
-        trx.walk_instructions().any(|view| {
-            query.matches_keys(
-                &view
-                    .accounts()
-                    .iter()
-                    .map(|acc| format!("account:{}", acc))
-                    .chain(vec![format!("program:{}", view.program_id())])
-                    .collect::<Vec<String>>(),
-            )
-        })
+        let keys: Vec<_> = transaction_program_and_account_keys(trx).collect();
+
+        query.matches_keys(&keys)
     });
 
     Ok(transactions)

--- a/solana-common/substreams-v0.3.1.yaml
+++ b/solana-common/substreams-v0.3.1.yaml
@@ -1,0 +1,50 @@
+specVersion: v0.1.0
+package:
+  name: "solana_common"
+  version: v0.3.1 # based on v0.2.0 to keep the caches on the existing modules
+  image: ./solana.png
+
+network: solana
+
+imports:
+  solana: https://github.com/streamingfast/firehose-solana/releases/download/v0.1.1/solana-v0.1.1.spkg
+  v020: https://spkg.io/streamingfast/solana-common-v0.2.0.spkg
+  v030: https://spkg.io/streamingfast/solana-common-v0.3.0.spkg
+
+binaries:
+  default:
+    type: wasm/rust-v1
+    file: ./target/wasm32-unknown-unknown/release/substreams.wasm
+
+modules:
+  - name: blocks_without_votes
+    use: v020:blocks_without_votes # unchanged from v0.2.0 to keep the same hashes and caches
+
+  - name: program_ids_without_votes
+    use: v020:program_ids_without_votes # unchanged from v0.2.0 to keep the same hashes and caches
+
+  - name: program_ids_and_accounts_without_votes
+    kind: blockIndex
+    inputs:
+      - map: blocks_without_votes
+    output:
+      type: proto:sf.substreams.index.v1.Keys
+
+  - name: transactions_by_programid_without_votes
+    use: v030:transactions_by_programid_without_votes # unchanged from v0.3.0 to keep the same hashes and caches
+
+  - name: transactions_by_programid_and_account_without_votes
+    kind: map
+    inputs:
+      - params: string
+      - map: blocks_without_votes
+    blockFilter:
+      module: program_ids_and_accounts_without_votes
+      query:
+        params: true
+    output:
+      type: proto:sf.substreams.solana.v1.Transactions
+
+params: # Default parameters for the filter modules. You can override these parameters based on your needs.
+  transactions_by_programid_without_votes: "program:4vMsoUT2BWatFweudnQM1xedRLfJgJ7hswhcpz4xgBTy"
+  transactions_by_programid_and_account_without_votes: "program:4vMsoUT2BWatFweudnQM1xedRLfJgJ7hswhcpz4xgBTy || (account:Gnt27xtC473ZT2Mw5u8wZ68Z3gULkSTb5DuxJy7eJotD && program:FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH)"

--- a/solana-common/substreams.yaml
+++ b/solana-common/substreams.yaml
@@ -1,1 +1,1 @@
-substreams-v0.3.0.yaml
+substreams-v0.3.1.yaml


### PR DESCRIPTION
The index now uses the full account maps instead of just those from the instructions.

Furthermore, the way the filtering is performed was scoped to instruction previously, e.g. that a full instruction needed to match the query to consider a transaction included. This is now changed, we instead take the set of program ids and accounts defined by the transaction, according to the new rules for accounts above, and if there is a match between this set, then the transaction is included.

This in most cases shouldn't affect anyone, as downstream code usually further filter instructions they are interesting in. But this changes is still consider breaking, as with the new methodology, transactions that didn't match before will now match.