### PR TITLE
stellar: fix map_events deterministic WASM failure (too many arguments)

### DIFF
--- a/stellar-common/CHANGELOG.md
+++ b/stellar-common/CHANGELOG.md
@@ -6,4 +6,8 @@ for instructions to keep up to date.
 
 ## v0.4.0
 
+### Fixed
+- Fix `map_events` WASM entrypoint crash ("too many arguments provided") by correcting its manifest inputs from `params: string` + `source: sf.stellar.type.v1.Block` to `map: map_transactions`, matching the actual Rust function signature.
+
+### Added
 * Added indexing of Stellar event's topics.

--- a/stellar-common/CHANGELOG.md
+++ b/stellar-common/CHANGELOG.md
@@ -4,10 +4,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See [MAINTAINERS.md](./MAINTAINERS.md)
 for instructions to keep up to date.
 
-## v0.4.0
+## Unreleased
 
 ### Fixed
 - Fix `map_events` WASM entrypoint crash ("too many arguments provided") by correcting its manifest inputs from `params: string` + `source: sf.stellar.type.v1.Block` to `map: map_transactions`, matching the actual Rust function signature.
 
-### Added
+## v0.5.0
+
+* Release v0.5.0
+
+## v0.4.0
+
 * Added indexing of Stellar event's topics.

--- a/stellar-common/substreams.yaml
+++ b/stellar-common/substreams.yaml
@@ -81,8 +81,7 @@ modules:
   - name: map_events
     kind: map
     inputs:
-      - params: string
-      - source: sf.stellar.type.v1.Block
+      - map: map_transactions
     output:
       type: proto:sf.substreams.stellar.type.v1.Events
 


### PR DESCRIPTION
## Summary

- Fixes a deterministic WASM execution failure on every block when running `map_events` (and therefore `filtered_events`) in `stellar-foundational v0.5.0`.
- The error `too many arguments provided` was caused by an ABI mismatch between the manifest and the compiled WASM entrypoint.

## Root Cause

`substreams.yaml` declared `map_events` with **two inputs**:
```yaml
inputs:
  - params: string
  - source: sf.stellar.type.v1.Block
```

But the Rust handler only accepts **one argument**:
```rust
fn map_events(transactions: Transactions) -> Result<Events, substreams::errors::Error>
```

The Substreams runtime called the WASM entrypoint with 2 arguments (as declared in the manifest), while the compiled function only accepted 1. This is a pure arity mismatch at the WASM boundary — content-independent, so it fails on every block.

There was also a type mismatch: the manifest said `sf.stellar.type.v1.Block`, but the function expects `sf.substreams.stellar.type.v1.Transactions` (the output of `map_transactions`).

## Fix

Replace both incorrect inputs with `map: map_transactions`, matching the actual Rust signature and following the same pattern as `map_operations`:

```yaml
inputs:
  - map: map_transactions
```

## Test plan

- [ ] All existing unit tests pass (`cargo test`)
- [ ] `map_events` runs without error on a live block: `substreams run stellar-foundational-v0.5.0.spkg map_events -e mainnet.stellar.streamingfast.io:443 -s 55411000 -t +1`
- [ ] `filtered_events` also works (depends on `map_events`)